### PR TITLE
fix: pass parameters as objects to native layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,15 @@ Start a new download task.
 ### pause(...)
 
 ```typescript
-pause(id: string) => Promise<void>
+pause(options: { id: string; }) => Promise<void>
 ```
 
 Pause an active download.
 Download can be resumed later from the same position.
 
-| Param    | Type                | Description                        |
-| -------- | ------------------- | ---------------------------------- |
-| **`id`** | <code>string</code> | - ID of the download task to pause |
+| Param         | Type                         | Description                               |
+| ------------- | ---------------------------- | ----------------------------------------- |
+| **`options`** | <code>{ id: string; }</code> | - Options containing the download task ID |
 
 --------------------
 
@@ -96,15 +96,15 @@ Download can be resumed later from the same position.
 ### resume(...)
 
 ```typescript
-resume(id: string) => Promise<void>
+resume(options: { id: string; }) => Promise<void>
 ```
 
 Resume a paused download.
 Continues from where it was paused.
 
-| Param    | Type                | Description                         |
-| -------- | ------------------- | ----------------------------------- |
-| **`id`** | <code>string</code> | - ID of the download task to resume |
+| Param         | Type                         | Description                               |
+| ------------- | ---------------------------- | ----------------------------------------- |
+| **`options`** | <code>{ id: string; }</code> | - Options containing the download task ID |
 
 --------------------
 
@@ -112,15 +112,15 @@ Continues from where it was paused.
 ### stop(...)
 
 ```typescript
-stop(id: string) => Promise<void>
+stop(options: { id: string; }) => Promise<void>
 ```
 
 Stop and cancel a download permanently.
 Downloaded data will be deleted.
 
-| Param    | Type                | Description                       |
-| -------- | ------------------- | --------------------------------- |
-| **`id`** | <code>string</code> | - ID of the download task to stop |
+| Param         | Type                         | Description                               |
+| ------------- | ---------------------------- | ----------------------------------------- |
+| **`options`** | <code>{ id: string; }</code> | - Options containing the download task ID |
 
 --------------------
 
@@ -128,14 +128,14 @@ Downloaded data will be deleted.
 ### checkStatus(...)
 
 ```typescript
-checkStatus(id: string) => Promise<DownloadTask>
+checkStatus(options: { id: string; }) => Promise<DownloadTask>
 ```
 
 Check the current status of a download.
 
-| Param    | Type                | Description                        |
-| -------- | ------------------- | ---------------------------------- |
-| **`id`** | <code>string</code> | - ID of the download task to check |
+| Param         | Type                         | Description                               |
+| ------------- | ---------------------------- | ----------------------------------------- |
+| **`options`** | <code>{ id: string; }</code> | - Options containing the download task ID |
 
 **Returns:** <code>Promise&lt;<a href="#downloadtask">DownloadTask</a>&gt;</code>
 
@@ -145,14 +145,14 @@ Check the current status of a download.
 ### getFileInfo(...)
 
 ```typescript
-getFileInfo(path: string) => Promise<{ size: number; type: string; }>
+getFileInfo(options: { path: string; }) => Promise<{ size: number; type: string; }>
 ```
 
 Get information about a downloaded file.
 
-| Param      | Type                | Description                  |
-| ---------- | ------------------- | ---------------------------- |
-| **`path`** | <code>string</code> | - Local file path to inspect |
+| Param         | Type                           | Description                        |
+| ------------- | ------------------------------ | ---------------------------------- |
+| **`options`** | <code>{ path: string; }</code> | - Options containing the file path |
 
 **Returns:** <code>Promise&lt;{ size: number; type: string; }&gt;</code>
 

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -34,7 +34,7 @@ return task;
 if (!id) {
   throw new Error('Provide a download id first.');
 }
-const status = await plugin.checkStatus(id);
+const status = await plugin.checkStatus({ id });
 return status;
               },
             },
@@ -48,7 +48,7 @@ return status;
 if (!id) {
   throw new Error('Provide a download id first.');
 }
-await plugin.pause(id);
+await plugin.pause({ id });
 return `Pause requested for ${id}.`;
               },
             },
@@ -62,7 +62,7 @@ return `Pause requested for ${id}.`;
 if (!id) {
   throw new Error('Provide a download id first.');
 }
-await plugin.resume(id);
+await plugin.resume({ id });
 return `Resume requested for ${id}.`;
               },
             },
@@ -76,7 +76,7 @@ return `Resume requested for ${id}.`;
 if (!id) {
   throw new Error('Provide a download id first.');
 }
-await plugin.stop(id);
+await plugin.stop({ id });
 return `Stop requested for ${id}.`;
               },
             },
@@ -89,7 +89,7 @@ return `Stop requested for ${id}.`;
                 if (!values.path) {
   throw new Error('Provide a file path.');
 }
-const info = await plugin.getFileInfo(values.path);
+const info = await plugin.getFileInfo({ path: values.path });
 return info;
               },
             }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -55,44 +55,44 @@ export interface CapacitorDownloaderPlugin {
    * Pause an active download.
    * Download can be resumed later from the same position.
    *
-   * @param id - ID of the download task to pause
+   * @param options - Options containing the download task ID
    * @returns Promise that resolves when paused
    */
-  pause(id: string): Promise<void>;
+  pause(options: { id: string }): Promise<void>;
 
   /**
    * Resume a paused download.
    * Continues from where it was paused.
    *
-   * @param id - ID of the download task to resume
+   * @param options - Options containing the download task ID
    * @returns Promise that resolves when resumed
    */
-  resume(id: string): Promise<void>;
+  resume(options: { id: string }): Promise<void>;
 
   /**
    * Stop and cancel a download permanently.
    * Downloaded data will be deleted.
    *
-   * @param id - ID of the download task to stop
+   * @param options - Options containing the download task ID
    * @returns Promise that resolves when stopped
    */
-  stop(id: string): Promise<void>;
+  stop(options: { id: string }): Promise<void>;
 
   /**
    * Check the current status of a download.
    *
-   * @param id - ID of the download task to check
+   * @param options - Options containing the download task ID
    * @returns Promise with current download task status
    */
-  checkStatus(id: string): Promise<DownloadTask>;
+  checkStatus(options: { id: string }): Promise<DownloadTask>;
 
   /**
    * Get information about a downloaded file.
    *
-   * @param path - Local file path to inspect
+   * @param options - Options containing the file path
    * @returns Promise with file size and MIME type
    */
-  getFileInfo(path: string): Promise<{ size: number; type: string }>;
+  getFileInfo(options: { path: string }): Promise<{ size: number; type: string }>;
 
   /**
    * Listen for download progress updates.

--- a/src/web.ts
+++ b/src/web.ts
@@ -7,24 +7,24 @@ export class CapacitorDownloaderWeb extends WebPlugin implements CapacitorDownlo
     console.log('DOWNLOAD', options);
     throw new Error('Method not implemented.');
   }
-  async pause(id: string): Promise<void> {
-    console.log('PAUSE', id);
+  async pause(options: { id: string }): Promise<void> {
+    console.log('PAUSE', options.id);
     throw new Error('Method not implemented.');
   }
-  async resume(id: string): Promise<void> {
-    console.log('RESUME', id);
+  async resume(options: { id: string }): Promise<void> {
+    console.log('RESUME', options.id);
     throw new Error('Method not implemented.');
   }
-  async stop(id: string): Promise<void> {
-    console.log('STOP', id);
+  async stop(options: { id: string }): Promise<void> {
+    console.log('STOP', options.id);
     throw new Error('Method not implemented.');
   }
-  async checkStatus(id: string): Promise<DownloadTask> {
-    console.log('CHECK STATUS', id);
+  async checkStatus(options: { id: string }): Promise<DownloadTask> {
+    console.log('CHECK STATUS', options.id);
     throw new Error('Method not implemented.');
   }
-  async getFileInfo(path: string): Promise<{ size: number; type: string }> {
-    console.log('GET FILE INFO', path);
+  async getFileInfo(options: { path: string }): Promise<{ size: number; type: string }> {
+    console.log('GET FILE INFO', options.path);
     throw new Error('Method not implemented.');
   }
 


### PR DESCRIPTION
## Summary

- Fixed parameter passing for `pause`, `resume`, `stop`, `checkStatus`, and `getFileInfo` methods
- Updated example app to use the corrected API

## Problem

Capacitor requires method parameters to be passed as objects with named properties. The native side uses `call.getString("id")` which looks for a property named `"id"` inside an object.

**Before (broken):**
```typescript
CapacitorDownloader.stop("my-id")  // Native receives bare string, call.getString("id") returns null
```

**After (works):**
```typescript
CapacitorDownloader.stop({ id: "my-id" })  // Native receives object, call.getString("id") works
```

## Changes

| Method | Before | After |
|--------|--------|-------|
| `pause` | `pause(id: string)` | `pause(options: { id: string })` |
| `resume` | `resume(id: string)` | `resume(options: { id: string })` |
| `stop` | `stop(id: string)` | `stop(options: { id: string })` |
| `checkStatus` | `checkStatus(id: string)` | `checkStatus(options: { id: string })` |
| `getFileInfo` | `getFileInfo(path: string)` | `getFileInfo(options: { path: string })` |

## Breaking Change

This is a **breaking change** for users calling these methods with bare strings. They will need to update to the object syntax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API documentation, README, and code examples updated to reflect the new standardized method parameter structures across all plugin methods.

* **Refactor**
  * Plugin API methods refactored to accept options objects instead of direct parameters. This standardization applies to all task control and file information retrieval operations, requiring users to update existing method calls accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->