### PR TITLE
fix(android): backport Android 14+ receiver registration fix to 7.x (#63)

### DIFF
--- a/android/src/main/java/ee/forgr/capacitor/plugin/downloader/CapacitorDownloaderPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor/plugin/downloader/CapacitorDownloaderPlugin.java
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import androidx.core.content.ContextCompat;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.Handler;
@@ -22,7 +23,7 @@ import java.util.Map;
 @CapacitorPlugin(name = "CapacitorDownloader")
 public class CapacitorDownloaderPlugin extends Plugin {
 
-    private final String pluginVersion = "7.2.12";
+    private final String pluginVersion = "7.2.13";
 
     private DownloadManager downloadManager;
     private final Map<String, Long> downloads = new HashMap<>();
@@ -46,7 +47,12 @@ public class CapacitorDownloaderPlugin extends Plugin {
                 }
             }
         };
-        getContext().registerReceiver(downloadReceiver, new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE));
+        ContextCompat.registerReceiver(
+            getContext(),
+            downloadReceiver,
+            new IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+            ContextCompat.RECEIVER_EXPORTED
+        );
     }
 
     private String getDownloadIdByValue(long value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@capgo/capacitor-downloader",
-  "version": "7.2.12",
+  "version": "7.2.13",
   "description": "Download file in background or foreground",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary

- Backports the Android 14+ broadcast receiver fix from #39 (`add0362`) to the 7.x line
- Uses `ContextCompat.registerReceiver` with `RECEIVER_EXPORTED` so `registerDownloadReceiver()` no longer throws on API 34+
- Bumps version to **7.2.13**

Without this change, `Plugin.load()` fails on Android 14+ and every JS call rejects with *"CapacitorDownloader plugin is not implemented on android"*.

Fixes #63

## Test plan

- [x] `bun run verify` (iOS, Android, web)
- [ ] Manual test on Android 14+ device/emulator: plugin registers and downloads complete


Made with [Cursor](https://cursor.com)