### PR TITLE
fix(ios): honor destination, reject non-2xx HTTP, add progress bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,16 +187,16 @@ Get information about a downloaded file.
 ### addListener('downloadProgress', ...)
 
 ```typescript
-addListener(eventName: 'downloadProgress', listenerFunc: (progress: { id: string; progress: number; }) => void) => Promise<PluginListenerHandle>
+addListener(eventName: 'downloadProgress', listenerFunc: (progress: { id: string; progress: number; bytesWritten?: number | undefined; bytesTotal?: number | undefined; }) => void) => Promise<PluginListenerHandle>
 ```
 
 Listen for download progress updates.
 Fired periodically as download progresses.
 
-| Param              | Type                                                                  | Description                           |
-| ------------------ | --------------------------------------------------------------------- | ------------------------------------- |
-| **`eventName`**    | <code>'downloadProgress'</code>                                       | - Must be 'downloadProgress'          |
-| **`listenerFunc`** | <code>(progress: { id: string; progress: number; }) =&gt; void</code> | - Callback receiving progress updates |
+| Param              | Type                                                                                                              | Description                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| **`eventName`**    | <code>'downloadProgress'</code>                                                                                   | - Must be 'downloadProgress'          |
+| **`listenerFunc`** | <code>(progress: { id: string; progress: number; bytesWritten?: number; bytesTotal?: number; }) =&gt; void</code> | - Callback receiving progress updates |
 
 **Returns:** <code>Promise&lt;<a href="#pluginlistenerhandle">PluginListenerHandle</a>&gt;</code>
 

--- a/ios/Sources/CapacitorDownloaderPlugin/CapacitorDownloaderPlugin.swift
+++ b/ios/Sources/CapacitorDownloaderPlugin/CapacitorDownloaderPlugin.swift
@@ -56,14 +56,37 @@ public class CapacitorDownloaderPlugin: CAPPlugin, CAPBridgedPlugin {
         return tasks.first(where: { $0.value == task })?.key
     }
 
+    private func documentsDirectoryURL() -> URL? {
+        FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+    }
+
+    private func destinationURL(for id: String, storedDestination: String?) -> URL? {
+        guard let documentsDirectory = documentsDirectoryURL() else {
+            return nil
+        }
+
+        return DownloadDestinationResolver.resolveDestinationURL(
+            destination: storedDestination,
+            id: id,
+            documentsDirectory: documentsDirectory
+        )
+    }
+
+    private func prepareDestinationDirectory(for destinationURL: URL) throws {
+        let directoryURL = destinationURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+    }
+
     @objc func download(_ call: CAPPluginCall) {
         guard let id = call.getString("id"),
               let urlString = call.getString("url"),
-              let destination = call.getString("destination"),
               let url = URL(string: urlString) else {
             call.reject("Invalid parameters")
             return
         }
+
+        let destination = call.getString("destination") ?? ""
+        DownloadDestinationStore.shared.setDestination(destination, for: id)
 
         var request = URLRequest(url: url)
         if let headers = call.getObject("headers") as? [String: String] {
@@ -115,6 +138,7 @@ public class CapacitorDownloaderPlugin: CAPPlugin, CAPBridgedPlugin {
 
         task.cancel()
         removeTask(for: id)
+        DownloadDestinationStore.shared.removeDestination(for: id)
         call.resolve()
     }
 
@@ -166,16 +190,39 @@ public class CapacitorDownloaderPlugin: CAPPlugin, CAPBridgedPlugin {
             "type": type
         ])
     }
+
+    @objc func getPluginVersion(_ call: CAPPluginCall) {
+        call.resolve(["version": self.pluginVersion])
+    }
 }
 
 extension CapacitorDownloaderPlugin: URLSessionDownloadDelegate {
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
-        guard let id = idForTask(downloadTask),
-              let destinationURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first?.appendingPathComponent(id) else {
+        guard let id = idForTask(downloadTask) else {
+            return
+        }
+
+        let storedDestination = DownloadDestinationStore.shared.takeDestination(for: id)
+        guard let destinationURL = destinationURL(for: id, storedDestination: storedDestination) else {
+            notifyListeners("downloadFailed", data: ["id": id, "error": "Unable to resolve destination"])
+            return
+        }
+
+        if let httpResponse = downloadTask.response as? HTTPURLResponse,
+           !DownloadHTTPValidator.isSuccessfulStatusCode(httpResponse.statusCode) {
+            try? FileManager.default.removeItem(at: location)
+            notifyListeners(
+                "downloadFailed",
+                data: ["id": id, "error": "HTTP \(httpResponse.statusCode)"]
+            )
             return
         }
 
         do {
+            try prepareDestinationDirectory(for: destinationURL)
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
             try FileManager.default.moveItem(at: location, to: destinationURL)
             notifyListeners("downloadCompleted", data: ["id": id])
         } catch {
@@ -191,22 +238,36 @@ extension CapacitorDownloaderPlugin: URLSessionDownloadDelegate {
 
         removeTask(for: id)
 
+        if error != nil {
+            _ = DownloadDestinationStore.shared.takeDestination(for: id)
+        }
+
         if let error = error {
             notifyListeners("downloadFailed", data: ["id": id, "error": error.localizedDescription])
         }
     }
 
-    public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+    public func urlSession(
+        _ session: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData bytesWritten: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
         guard let id = idForTask(downloadTask) else {
             return
         }
 
-        let progress = Float(totalBytesWritten) / Float(totalBytesExpectedToWrite)
-        notifyListeners("downloadProgress", data: ["id": id, "progress": progress])
+        let bytesTotal = totalBytesExpectedToWrite > 0 ? totalBytesExpectedToWrite : 0
+        let progress = bytesTotal > 0 ? Float(totalBytesWritten) / Float(bytesTotal) : 0
+        notifyListeners(
+            "downloadProgress",
+            data: [
+                "id": id,
+                "progress": progress,
+                "bytesWritten": totalBytesWritten,
+                "bytesTotal": bytesTotal
+            ]
+        )
     }
-
-    @objc func getPluginVersion(_ call: CAPPluginCall) {
-        call.resolve(["version": self.pluginVersion])
-    }
-
 }

--- a/ios/Sources/CapacitorDownloaderPlugin/DownloadDestinationResolver.swift
+++ b/ios/Sources/CapacitorDownloaderPlugin/DownloadDestinationResolver.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum DownloadDestinationResolver {
+    static func resolveDestinationURL(
+        destination: String?,
+        id: String,
+        documentsDirectory: URL
+    ) -> URL {
+        let trimmedDestination = destination?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let destination = trimmedDestination, !destination.isEmpty else {
+            return documentsDirectory.appendingPathComponent(id)
+        }
+
+        if destination.hasPrefix("file://"), let url = URL(string: destination) {
+            return url
+        }
+
+        if destination.hasPrefix("/") {
+            return URL(fileURLWithPath: destination)
+        }
+
+        return documentsDirectory.appendingPathComponent(destination)
+    }
+}

--- a/ios/Sources/CapacitorDownloaderPlugin/DownloadDestinationStore.swift
+++ b/ios/Sources/CapacitorDownloaderPlugin/DownloadDestinationStore.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+final class DownloadDestinationStore {
+    static let shared = DownloadDestinationStore()
+
+    static let userDefaultsKey = "CapacitorDownloaderDestinations"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func setDestination(_ destination: String, for id: String) {
+        var map = destinationsMap()
+        map[id] = destination
+        defaults.set(map, forKey: Self.userDefaultsKey)
+    }
+
+    func takeDestination(for id: String) -> String? {
+        var map = destinationsMap()
+        let destination = map.removeValue(forKey: id)
+        defaults.set(map, forKey: Self.userDefaultsKey)
+        return destination
+    }
+
+    func removeDestination(for id: String) {
+        var map = destinationsMap()
+        map.removeValue(forKey: id)
+        defaults.set(map, forKey: Self.userDefaultsKey)
+    }
+
+    private func destinationsMap() -> [String: String] {
+        defaults.dictionary(forKey: Self.userDefaultsKey) as? [String: String] ?? [:]
+    }
+}

--- a/ios/Sources/CapacitorDownloaderPlugin/DownloadHTTPValidator.swift
+++ b/ios/Sources/CapacitorDownloaderPlugin/DownloadHTTPValidator.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum DownloadHTTPValidator {
+    static func isSuccessfulStatusCode(_ statusCode: Int) -> Bool {
+        statusCode >= 200 && statusCode < 300
+    }
+}

--- a/ios/Tests/CapacitorDownloaderPluginTests/CapacitorDownloaderPluginTests.swift
+++ b/ios/Tests/CapacitorDownloaderPluginTests/CapacitorDownloaderPluginTests.swift
@@ -1,15 +1,102 @@
 import XCTest
 @testable import CapacitorDownloaderPlugin
 
-class CapacitorDownloaderTests: XCTestCase {
-    func testEcho() {
-        // This is an example of a functional test case for a plugin.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+final class DownloadDestinationResolverTests: XCTestCase {
+    private let documentsDirectory = URL(fileURLWithPath: "/var/mobile/Documents")
 
-        let implementation = CapacitorDownloader()
-        let value = "Hello, World!"
-        let result = implementation.echo(value)
+    func testEmptyDestinationFallsBackToDocumentsPlusId() {
+        let url = DownloadDestinationResolver.resolveDestinationURL(
+            destination: nil,
+            id: "download-1",
+            documentsDirectory: documentsDirectory
+        )
 
-        XCTAssertEqual(value, result)
+        XCTAssertEqual(url, documentsDirectory.appendingPathComponent("download-1"))
+    }
+
+    func testBlankDestinationFallsBackToDocumentsPlusId() {
+        let url = DownloadDestinationResolver.resolveDestinationURL(
+            destination: "   ",
+            id: "download-1",
+            documentsDirectory: documentsDirectory
+        )
+
+        XCTAssertEqual(url, documentsDirectory.appendingPathComponent("download-1"))
+    }
+
+    func testRelativeDestinationUsesDocumentsDirectory() {
+        let url = DownloadDestinationResolver.resolveDestinationURL(
+            destination: "downloads/sample.zip",
+            id: "download-1",
+            documentsDirectory: documentsDirectory
+        )
+
+        XCTAssertEqual(url, documentsDirectory.appendingPathComponent("downloads/sample.zip"))
+    }
+
+    func testAbsolutePathUsesFileURL() {
+        let url = DownloadDestinationResolver.resolveDestinationURL(
+            destination: "/tmp/custom-file.bin",
+            id: "download-1",
+            documentsDirectory: documentsDirectory
+        )
+
+        XCTAssertEqual(url, URL(fileURLWithPath: "/tmp/custom-file.bin"))
+    }
+
+    func testFileURLDestinationIsUsedDirectly() {
+        let url = DownloadDestinationResolver.resolveDestinationURL(
+            destination: "file:///tmp/custom-file.bin",
+            id: "download-1",
+            documentsDirectory: documentsDirectory
+        )
+
+        XCTAssertEqual(url, URL(string: "file:///tmp/custom-file.bin"))
+    }
+}
+
+final class DownloadDestinationStoreTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var store: DownloadDestinationStore!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: "CapacitorDownloaderPluginTests")!
+        defaults.removePersistentDomain(forName: "CapacitorDownloaderPluginTests")
+        store = DownloadDestinationStore(defaults: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: "CapacitorDownloaderPluginTests")
+        super.tearDown()
+    }
+
+    func testSetAndTakeDestination() {
+        store.setDestination("downloads/file.zip", for: "task-1")
+
+        XCTAssertEqual(store.takeDestination(for: "task-1"), "downloads/file.zip")
+        XCTAssertNil(store.takeDestination(for: "task-1"))
+    }
+
+    func testRemoveDestination() {
+        store.setDestination("downloads/file.zip", for: "task-1")
+
+        store.removeDestination(for: "task-1")
+
+        XCTAssertNil(store.takeDestination(for: "task-1"))
+    }
+}
+
+final class DownloadHTTPValidatorTests: XCTestCase {
+    func testSuccessfulStatusCodes() {
+        XCTAssertTrue(DownloadHTTPValidator.isSuccessfulStatusCode(200))
+        XCTAssertTrue(DownloadHTTPValidator.isSuccessfulStatusCode(204))
+        XCTAssertTrue(DownloadHTTPValidator.isSuccessfulStatusCode(299))
+    }
+
+    func testNonSuccessfulStatusCodesAreRejected() {
+        XCTAssertFalse(DownloadHTTPValidator.isSuccessfulStatusCode(199))
+        XCTAssertFalse(DownloadHTTPValidator.isSuccessfulStatusCode(404))
+        XCTAssertFalse(DownloadHTTPValidator.isSuccessfulStatusCode(500))
     }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "verify": "npm run verify:ios && npm run verify:android && npm run verify:web",
-    "verify:ios": "xcodebuild -scheme CapgoCapacitorDownloader -destination generic/platform=iOS",
+    "verify:ios": "xcodebuild test -scheme CapgoCapacitorDownloader -destination 'platform=iOS Simulator,name=iPhone 16' -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO",
     "verify:android": "cd android && ./gradlew clean build test && cd ..",
     "verify:web": "npm run build",
     "lint": "npm run eslint && npm run prettier -- --check && npm run swiftlint -- lint",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -110,7 +110,14 @@ export interface CapacitorDownloaderPlugin {
    */
   addListener(
     eventName: 'downloadProgress',
-    listenerFunc: (progress: { id: string; progress: number }) => void,
+    listenerFunc: (progress: {
+      id: string;
+      progress: number;
+      /** Bytes written so far */
+      bytesWritten?: number;
+      /** Total bytes expected, or 0 when the server did not report a length */
+      bytesTotal?: number;
+    }) => void,
   ): Promise<PluginListenerHandle>;
 
   /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
- iOS now honors the `destination` option passed to `download()`, persisting it in UserDefaults so background `URLSession` completions can resolve the final file path after process relaunch
- Non-2xx HTTP responses are rejected in `didFinishDownloadingTo` and emit `downloadFailed` instead of saving the error body
- `downloadProgress` events now include `bytesWritten` and `bytesTotal` (0 when content length is unknown)
- Added XCTest coverage for destination resolution, destination persistence, and HTTP status validation
- Updated `verify:ios` to run XCTest on CI

## Why
Fixes #76. iOS accepted `destination` in the API but always wrote to `Documents/<id>`. Callers also could not weigh multi-file progress by size, and HTTP error pages were saved as successful downloads.

## How
- Extracted `DownloadDestinationResolver`, `DownloadDestinationStore`, and `DownloadHTTPValidator` helpers for testability
- On download start: store the raw destination string keyed by download id
- On finish/fail/stop: resolve and remove the stored destination
- Destination rules:
  - `file://...` → that URL
  - absolute path starting with `/` → file URL
  - relative/other → Documents + relative path
  - missing/empty → Documents + id (previous behavior)
- Before moving the temp file, validate HTTP status is 200–299
- Progress listener payload includes byte counts alongside progress ratio
- Extended `src/definitions.ts` with optional `bytesWritten` / `bytesTotal` and regenerated docs via `bun run build`

## Testing
- `bun run build`
- `bun run fmt`
- `bun run lint`
- `bun run verify:web`
- Added XCTest cases in `ios/Tests/CapacitorDownloaderPluginTests/CapacitorDownloaderPluginTests.swift` for destination resolution (relative, `file://`, absolute, empty fallback), UserDefaults store take/remove, and non-2xx HTTP rejection helper
- iOS simulator tests run via updated `verify:ios` on macOS CI

## Not Tested
- Manual device test with a live background download relaunch
- Android changes (already honors destination via `DownloadManager`)

Closes #76
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2ea59dc-4bd4-466b-b2a4-02516d27669c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2ea59dc-4bd4-466b-b2a4-02516d27669c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Cap-go/codesmith/capacitor-downloader/pr/77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790331411&installation_model_id=430928&pr_number=77&repository=Cap-go%2Fcapacitor-downloader&return_to=https%3A%2F%2Fgithub.com%2FCap-go%2Fcapacitor-downloader%2Fpull%2F77&signature=404a1f461ab00c50af47a4cdd47e2aa5aa000c4a0b9f44a1544245fc94ecc569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/Cap-go/capacitor-downloader/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

